### PR TITLE
Docs polish

### DIFF
--- a/1_data_exploration_significance_estimation.ipynb
+++ b/1_data_exploration_significance_estimation.ipynb
@@ -10,7 +10,7 @@
     "## 1.1. Context\n",
     "In this first tutorial we will consider the brightest steady gamma-ray source in the sky: the Crab Nebula.   \n",
     "Due to these properties, the source is considered a reference source in gamma-ray astronomy at very high energies (VHE, $E>100\\,{\\rm GeV}$).   \n",
-    "We will explore the gamma-ray data, focusing on the list of events, and then learn how to estimate the significance of the gamma-ray signal coming from the source.\n"
+    "We will explore the gamma-ray data, focusing on the list of events (i.e. individual gamma-ray photon detections), and then learn how to estimate the significance of the gamma-ray signal coming from the source.\n"
    ]
   },
   {
@@ -36,7 +36,6 @@
     "from gammapy.estimators import FluxPointsEstimator\n",
     "from gammapy.stats import wstat, WStatCountsStatistic\n",
     "\n",
-    "\n",
     "# - setting up logging and ignoring warnings\n",
     "logger = logging.getLogger(__name__)\n",
     "logger.setLevel(logging.INFO)\n",
@@ -50,7 +49,8 @@
    "source": [
     "## 1.2. Data exploration\n",
     "\n",
-    "Let us first take a look at the content of the high-level data. `Gammapy`'s `DataStore` will allow us to load all the data in a directory at once, that is all the Crab Nebula data for this case. Each file corresponds to a batch of data acquisition of roughly 20 minutes, that we call \"run\", and is represented by `Gammapy`'s `Observation` class."
+    "Let us first take a look at the content of the high-level data. `Gammapy`'s `DataStore` will allow us to load all the data in a directory at once, that is all the Crab Nebula data for this case. Each file corresponds to a batch of data acquisition of roughly 20 minutes, that we call \"run\", and is represented by `Gammapy`'s `Observation` class.\n",
+    "We require that certain properties of the instrument response function (IRF) are available: the maximum angular separation used for event selection (rad_max), the effective area (aeff), and the energy dispersion (edisp). See Sec. 1.4 for details on the latter two and Sec. 2.1.1 for the former."
    ]
   },
   {
@@ -90,6 +90,8 @@
    "id": "4b35b109-01c1-42dc-a488-680579a80011",
    "metadata": {},
    "source": [
+    "Each column in the event list is stored as an [Astropy Quantity](https://docs.astropy.org/en/stable/units/quantity.html), meaning that the values carry explicit physical units (e.g. `events.energy` is an array of energies with the unit `TeV` attached). This allows safe unit conversions, which will be used later when plotting.\n",
+    "\n",
     "Let us set aside the temporal information for the moment, and let us try to histogram the energy and coordinates to check their distribution."
    ]
   },
@@ -153,7 +155,7 @@
    "id": "51ae288b-376e-4abc-acbe-9644e8b8b84d",
    "metadata": {},
    "source": [
-    "An excess of events appears around coordinates ${\\rm R.A.} \\sim 83.5^{\\circ}$ and Dec ${\\rm Dec} \\sim 22^{\\circ}$, very close to the coordinates of the Crab Nebula. Let us then add the coordinates of the Crab Nebula in the plot."
+    "An excess of events appears around coordinates ${\\rm R.A.} \\sim 83.5^{\\circ}$ and Dec ${\\rm Dec} \\sim 22^{\\circ}$, very close to the coordinates of the Crab Nebula. Let us then add the coordinates of the Crab Nebula from [Simbad](https://simbad.u-strasbg.fr/simbad/sim-id?Ident=Crab+Nebula) in the plot."
    ]
   },
   {
@@ -319,7 +321,7 @@
     "\n",
     "What do we do with these two numbers? What we are really interested in determining is whether the signal is real, or if this data could plausibly come from fluctuations of the background. How should we proceed about it?\n",
     "\n",
-    "First of all, we assume that both the events in the _on_ and _off_ regions follow a Poisson distribution. If $g$, and $b$ represent the _expected number of signal and background events_, then we have\n",
+    "First of all, we assume that both the events in the _on_ and _off_ regions follow a Poisson distribution. If $g$, and $b$ represent the _expected number of signal and background events_, which we can’t observe directly but want to estimate, then we have\n",
     "\n",
     "$$\n",
     "P(g, b; N_{\\rm on}) = \\frac{(g + b)^{N_{\\rm on}} \\exp{[-(g + b)]}}{N_{\\rm on}!},\n",
@@ -328,7 +330,8 @@
     "\\tag{1.1}\n",
     "$$\n",
     "\n",
-    "If we estimate the background from more than one region, we can introduce the factor $\\alpha$ which is the ratio of the exposure (might mean area or also observation time) of the _on_ region to the exposure of the _off_ region. If instead of using a single _off_ region as we did in our example, we had considered $3$ other circular regions (always symmetric from the centre), then we would have $\\alpha = 1/3$. In this case, we modify our probability for the _on_ events into\n",
+    "If we estimate the background from more than one region, we can introduce the factor $\\alpha$ which is the ratio of the exposure (might mean area or also observation time) of the _on_ region to the exposure of the _off_ region. In this case, $b$ denotes the expected number of background events in all _off_ regions combined, and $\\alpha b$ gives the expected background in the _on_ region.\n",
+    "If instead of using a single _off_ region as we did in our example, we had considered $3$ other circular regions (always symmetric from the centre), then we would have $\\alpha = 1/3$. In this case, we modify our probability for the _on_ events into\n",
     "$$\n",
     "P(g, b, \\alpha; N_{\\rm on}) = \\frac{(g + \\alpha b)^{N_{\\rm on}} \\exp{[-(g + \\alpha b)]}}{N_{\\rm on}!}.\n",
     "\\tag{1.2}\n",
@@ -467,7 +470,8 @@
     "\n",
     "Another common method to visualise the presence of a signal, and to compute its statistical significance, is to build a $\\theta^2$ histogram. Instead of simply counting the events in the _on_ and _off_ regions, we make a histogram of their squared angular distances from the region centres: source position for _on_, and the region-centres for _off_. To determine the quantities $N_{\\rm on}$ and $N_{\\rm off}$, we count all the bin values within a cut in $\\theta^2$ that is basically the size of the _on_ region squared. With this method one can nicely visualise the presence of the signal in the _on_ region, as the counts steadily increase as we approach the zero, that is the centre of the _on_ region that in turn corresponds to the source position.\n",
     "\n",
-    "**Question 1.2**: Why an histogram of the distances **squared**?"
+    "Let us build the $\\theta^2$ distribution, the squared angular distance between the event directions and the region centers.\n",
+    "By plotting the histograms for the _on_ and _off_ regions, and their difference, we can see how the signal stands out above the background.\n"
    ]
   },
   {
@@ -535,6 +539,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9fcf7b03",
+   "metadata": {},
+   "source": [
+    "**Question 1.2**: Why an histogram of the distances **squared**?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "16d0066a-59cd-495a-8910-df788a295ce2",
    "metadata": {},
    "source": [
@@ -556,19 +568,41 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df011699-9f71-437f-9db2-4ce63f567c84",
+   "id": "ddbb2ace",
    "metadata": {},
    "source": [
     "### Exercise 1.1.\n",
     "\n",
-    "Create a $\\theta^2$ plot using **all** the 98 observations in the Crab Nebula data set. What is the total significance of the signal?\n",
-    "\n",
+    "Create a $\\theta^2$ plot using **all** the 98 observations in the Crab Nebula data set. What is the total significance of the signal?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de10a811",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df011699-9f71-437f-9db2-4ce63f567c84",
+   "metadata": {},
+   "source": [
     "### Exercise 1.2.\n",
     "It might be useful to determine whether our source has significant emission above a certain energy.   \n",
     "The presence of gamma rays above a given energy can indeed directly be related to a certain energy of the parent cosmic rays. For example, in certain physical scenarios, the gamma-ray energy is approximately a factor 10 lower than the parent cosmic-ray energy. Thus, a source with gamma-ray emission up to $10\\,{\\rm TeV}$, would be accelerating cosmic rays to hundreds of ${\\rm TeV}$.\n",
     "\n",
     "Using **all** the 98 observations in the Crab Nebula data set, compute the significance of the emission above $1$ and $10$ ${\\rm TeV}$."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea5f768e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -602,7 +636,7 @@
    "id": "990beb17-3b78-4f17-9328-0c30213f5870",
    "metadata": {},
    "source": [
-    "As we only have energy dependence, we can then plot"
+    "As we only have energy dependence, we can then plot this energy dependence for each of the four offsets, which are identical in this case."
    ]
   },
   {
@@ -690,13 +724,21 @@
     "### Homework 1.1.\n",
     "Could you make a similar histogram using **all** the 98 observations in the Crab Nebula data set?"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "556eac97",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:gammapy-1.3]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-gammapy-1.3-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -708,7 +750,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.12"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,

--- a/2_spectrum_estimation.ipynb
+++ b/2_spectrum_estimation.ipynb
@@ -18,7 +18,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# - basic imports (numpy, astropy, regions, matplotlib)\n",
+    "# - basic imports (numpy, astropy, regions, matplotlib) \n",
     "import numpy as np\n",
     "import astropy.units as u\n",
     "from astropy.coordinates import SkyCoord\n",
@@ -60,7 +60,7 @@
    "source": [
     "## 2.1. Spectrum Extraction\n",
     "\n",
-    "Let us make start from the previous homework, but let us do it with `Gammapy`!    \n",
+    "Let us start from the previous homework, but let us do it with `Gammapy`!    \n",
     "We aim at building histograms of the events in the _on_ and _off_ regions as a function of the energy. By estimating the _spectrum_, we mean we would like to find a description, through an analytical function, of this distribution in energy."
    ]
   },
@@ -90,9 +90,9 @@
    "id": "6726ef8c-1d99-4865-9f40-f72e3fc054c0",
    "metadata": {},
    "source": [
-    "In general, with increasing energy, the spatial resolution of the telescope will improve. This means that we might use tighter $\\theta^2$ cuts (i.e. smaller _on_ and _off_ regions), the idea being that the $\\theta^2$ histogram will become much more peaked as the energy increase (could you observe this in Exercise 1.2?). \n",
+    "In general, with increasing energy, the spatial resolution of the telescope will improve. This means that we might use tighter $\\theta^2$ cuts (i.e. smaller _on_ and _off_ regions), the idea being that the $\\theta^2$ histogram will become much more peaked as the energy increases (could you observe this in Exercise 1.2?). \n",
     "\n",
-    "Pre-optimised $\\theta^2$ cuts are available in the `rad_max` attribute of each observations. They correspond to the `RAD_MAX` data unit in the `.fits` file. We plot the optimised $\\theta^2$ cut in each bin, and, for comparison, the $\\theta^2$ cut we used in the previous tutorial."
+    "Pre-optimised $\\theta^2$ cuts are available in the `rad_max` attribute of each observation. They correspond to the `RAD_MAX` data unit in the `.fits` file. We plot the optimised $\\theta^2$ cut in each bin, and, for comparison, the $\\theta^2$ cut we used in the previous tutorial."
    ]
   },
   {
@@ -129,7 +129,7 @@
    "source": [
     "### 2.1.2. From `Observations` to `Datasets`\n",
     "\n",
-    "We will now delegate all the steps of spectrum extraction to `Gammapy` (we'll basically let `Gammapy` do the homework we had in the previous tutorial)."
+    "We will now delegate all the steps of spectrum extraction to `Gammapy` (we will basically let `Gammapy` do the homework we had in the previous tutorial)."
    ]
   },
   {
@@ -213,7 +213,7 @@
     "How should we use them, and what does it mean to estimate a spectrum?\n",
     "\n",
     "\n",
-    "To obtain a measurement of the specturm, it is commonly assumed that a simple analytical function describes the gamma-ray (differential) flux vs energy. The most common example is a power-law\n",
+    "To obtain a measurement of the specturm, it is commonly assumed that a simple analytical function describes the gamma-ray (differential) flux $\\Phi$ vs energy. The most common example is a power-law\n",
     "\n",
     "$$\n",
     "    \\frac{{\\rm d}\\phi}{{\\rm d}E}(E; \\Phi_0, \\Gamma, E_0)\\,[{\\rm TeV}^{-1}\\,{\\rm cm}^{-2}\\,{\\rm s}^{-1}] = \n",
@@ -221,7 +221,19 @@
     "    \\tag{2.1}\n",
     "$$\n",
     "\n",
-    "Let us look at some measurement of the spectrum of the Crab from other publications."
+    "where $\\Phi_0$ is the flux normalization at the reference energy $E_0$, $\\Gamma$ is the spectral index (slope of the power law), and $E_0$ is the reference energy (commonly chosen near the middle of the fitted energy range).  \n",
+    "\n",
+    "Another commonly used spectral model is the log-parabola, which allows for curvature in the spectrum:  \n",
+    "\n",
+    "$$\n",
+    "\\frac{{\\rm d}\\phi}{{\\rm d}E}(E; \\Phi_0, \\Gamma, \\beta, E_0) =\n",
+    "\\Phi_0 \\left(\\frac{E}{E_0}\\right)^{-\\Gamma - \\beta \\, \\log\\!\\left(\\frac{E}{E_0}\\right)}\n",
+    "\\tag{2.2}\n",
+    "$$\n",
+    "\n",
+    "where $\\beta$ is the curvature parameter (with $\\beta = 0$ the model reduces to a pure power law).\n",
+    "\n",
+    "Let us look at measurements of the spectrum of the Crab from publications."
    ]
   },
   {
@@ -303,7 +315,7 @@
    "id": "f765e1b6-b7cf-4746-857e-6a758d72c3f6",
    "metadata": {},
    "source": [
-    "We would like to find the flux vs energy (the parameters, given an assumed specrum) that would produce in our detector the same counts we observed. The issue is that while flux is an absolute physical quantity, while the data that we observed, the counts, are not an absolute quantities, but rather depend on our detector.\n",
+    "We would like to find the flux vs energy (the parameters, given an assumed specrum) that would produce in our detector the same counts we observed. The issue is that flux is an absolute physical quantity, whereas the data (observed counts) are not absolute as they depend on our detector.\n",
     "\n",
     "How can we adjust the parameters $\\hat{\\theta}$ of the analytical spectrum to the counts that we have extracted? That's where the IRF come into place. The IRF allow us to go from gamma-ray flux to instrument counts and vice versa. By folding (i.e. convolving) the analytical flux model with the response of the system we can obtain counts vs energy. \n",
     "\n",
@@ -316,9 +328,9 @@
     "\\tag{2.2}\n",
     "$$\n",
     "\n",
-    "where $A_{\\rm eff}(E)$ represent the effective area and $M(E'|E)$ the energy dispersion.\n",
+    "where $A_{\\rm eff}(E)$ represents the effective area and $M(E'|E)$ the energy dispersion.\n",
     "\n",
-    "How we decide which (predicted) counts better describe our model? With a likelihood, specifically the one we already introduced in the previous notebook, in Eq. 1.3. We have to keep into account that we have counts as a function of the energy, therefore, we have to produce a likelihood term for each of the estimated energy bins. The total likelihood for our dataset, accounting for the observed and estimated counts in each energy bin, reads:\n",
+    "How can we decide which (predicted) counts best describe our model? We do this by using a likelihood, specifically the one we already introduced in the previous notebook, in Eq. 1.3. We have to take into account that we have counts as a function of the energy, therefore, we have to produce a likelihood term for each of the estimated energy bins. The total likelihood for our dataset, accounting for the observed and estimated counts in each energy bin, reads:\n",
     "\n",
     "$$ \n",
     "\\mathcal{L}(\\hat{\\theta}) = \n",
@@ -326,7 +338,7 @@
     "\\tag{2.3}\n",
     "$$\n",
     "\n",
-    "where $i$ is an index that runs over $N$ estimated energy bins, and with the notation $g_i(\\hat{\\theta})$ I have remarked that the number of expected signal counts depend on the model parameters. $b_i$, the number of background counts, is typically treated as a nuisance parameter. The likelihood is maximised by varying the spectral parameters $\\hat{\\theta}$, and hence the number of predicted counts. `Gammapy` will take care of all these computations for ourselves.\n",
+    "where $i$ is an index that runs over $N$ estimated energy bins, and with the notation $g_i(\\hat{\\theta})$ denoting that the number of expected signal counts depend on the model parameters. $b_i$, the number of background counts, is typically treated as a nuisance parameter. The likelihood is maximised by varying the spectral parameters $\\hat{\\theta}$, and hence the number of predicted counts. `Gammapy` will take care of all these computations for us.\n",
     "\n",
     "It is customary to fit the spectrum in an energy range that is determined by the observing conditions (especially the zenith angle that impacts the energy threshold of the instrument)."
    ]
@@ -369,7 +381,7 @@
    "id": "f512df77-8db9-4ee9-922f-d922d3b9db04",
    "metadata": {},
    "source": [
-    "We can see the parameters, and now that we have assigned hte model, we can see something else."
+    "We can see the parameters, and now that we have assigned the model, we can see something else."
    ]
   },
   {
@@ -449,7 +461,7 @@
    "id": "313c7d29-01b0-4d37-94a9-ee0ad45e1778",
    "metadata": {},
    "source": [
-    "You have now an intuition of how the fitting routine work. The parameters will be changed until the best agreement between observed and predicted counts is observed. This agreement is statistically quantified by the likelihood, which is what is actually maximised."
+    "You have now an intuition of how the fitting routine works. The parameters will be changed until the best agreement between observed and predicted counts is found. This agreement is statistically quantified by the likelihood, which is what is actually maximised."
    ]
   },
   {
@@ -482,7 +494,7 @@
    "id": "f6eaef7e-4ef3-49d5-8a15-5835ab6ed0c1",
    "metadata": {},
    "source": [
-    "We can now plot the spectrum obtained by our fitting procedure. It is common in high-energy astrophysics, to represent instead of the differential flux the Spectral Energy Distribution (SED) obtained as $E^2\\frac{{\\rm d}\\phi}{{\\rm d}E} [{\\rm TeV}^{-1}\\,{\\rm cm}^{-2}\\,{\\rm s}^{-1}]$ that represent the how the emitted power is distributed over the electromagnetic spectrum. We compare the results we have obtained with a theoretical model of the SED and with another measurement performed by MAGIC."
+    "We can now plot the spectrum obtained by our fitting procedure. It is common in high-energy astrophysics, to represent instead of the differential flux the Spectral Energy Distribution (SED) obtained as $E^2\\frac{{\\rm d}\\phi}{{\\rm d}E} [{\\rm TeV}^{-1}\\,{\\rm cm}^{-2}\\,{\\rm s}^{-1}]$ that represent the how the emitted power is distributed over the electromagnetic spectrum. We compare the results we have obtained with a theoretical model of the SED and with another measurement performed by MAGIC.\n"
    ]
   },
   {
@@ -552,12 +564,12 @@
     "## 2.4. Flux Points\n",
     "\n",
     "Finally we also compute spectral data points or _flux points_. They are basically a flux measurement over different energy bins. Broadly speaking, they have two objectives:\n",
-    "1) when we fit the broad-band spectrum via the likelihood maximisation - as we have just shown - we are assuming that the entire spectrum is described by a single analytic smooth functions. This type of analysis is therefore not sensitive to any sharp feature in the spectrum;\n",
-    "2) we are adopting an analytical function to provide a broad-band flux measurements, yet, at a later stage, other astrophysicists might want to fit a physical model to our gamma-ray data. In order to do so they should have access to the data sets (counts + IRF) that we are using. In case this data are proprietary we can provide a simplified and easier to handle flux measurements.\n",
+    "1) when we fit the broad-band spectrum via the likelihood maximisation - as we have just shown - we are assuming that the entire spectrum is described by a single analytic smooth function. This type of analysis is therefore not sensitive to any sharp feature in the spectrum;\n",
+    "2) we are adopting an analytical function to provide a broad-band flux measurements, yet, at a later stage, other astrophysicists might want to fit a physical model to our gamma-ray data. In order to do so they should have access to the data sets (counts + IRF) that we are using. In case this data are proprietary we can provide a simplified and easier way to handle flux measurements.\n",
     "\n",
-    "To compute flux points, Gammapy starts from the best-fit spectrum obtained from the broad-band likelihood fit and re-adjusts it spearately to the events within each energy bin. Note theat only the amplitude ($\\phi_0$ in Eq. 2.1) of the spectrum is re-fitted. Basically, the spectrum we obtained from the broad-band likelihood fit is scaled up and down to adjust independently to the counts in each energy bin.\n",
+    "To compute flux points, `Gammapy` starts from the best-fit spectrum obtained from the broad-band likelihood fit and re-adjusts it spearately to the events within each energy bin. Note theat only the amplitude ($\\phi_0$ in Eq. 2.1) of the spectrum is re-fitted. Basically, the spectrum we obtained from the broad-band likelihood fit is scaled up and down to adjust independently to the counts in each energy bin.\n",
     "\n",
-    "Let us use the same binning we have used in estimated energies and select an interval compatible with what used in the likelihood fit."
+    "Let us use the same binning we have used in estimated energies and select an interval compatible with what was used in the likelihood fit."
    ]
   },
   {
@@ -616,17 +628,25 @@
     "\n",
     "When estimating the spectral parameters using all the observations, we have a likelihood term like in Eq. 2.3 for each of the runs.  \n",
     "When we _stack_ the observations, we create a single `SpectrumDataset` from all the observations together.   \n",
-    "_on_ and _off_ counts are simply summed in each estimated energy bin, IRF components are averaged weighting them with the observation time.\n",
+    "_on_ and _off_ counts are simply summed in each estimated energy bin, IRF components are averaged, weighted by the observation time.\n",
     "\n",
     "Stack all the Crab Nebula observations (check the `Gammapy` docs) and re-perform the fit using the single dataset thus obtained. Check the results against those of the fit using all the observations simultaneously."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6140216",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:gammapy-1.3]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-gammapy-1.3-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -638,7 +658,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.12"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,

--- a/3_light_curve_variable_source.ipynb
+++ b/3_light_curve_variable_source.ipynb
@@ -63,8 +63,7 @@
     "\n",
     "warnings.filterwarnings(\"ignore\")\n",
     "with warnings.catch_warnings():\n",
-    "    warnings.simplefilter('ignore', VerifyWarning)\n",
-    "    # do stuff here"
+    "    warnings.simplefilter('ignore', VerifyWarning)"
    ]
   },
   {
@@ -74,7 +73,7 @@
    "source": [
     "## 3.2. Data Reduction\n",
     "As before, let us load all the Mrk421 observations and reduce the data.   \n",
-    "Let us focus on the days between the 10th and the 20th of April, where the most intense activity was recorded. Let us `Gammapy's` `Observations.select_time` to select these observations."
+    "Let us focus on the days between the 10th and the 20th of April, where the most intense activity was recorded, by using `Gammapy's` `Observations.select_time` to select these observations."
    ]
   },
   {
@@ -101,7 +100,7 @@
    "id": "1403bb69-78c8-4751-92a7-b23a912d9abd",
    "metadata": {},
    "source": [
-    "As you noticed we used times from noon to noon. That's just because, as most of the observations happen over night (typically between 20:00 and 06:00, of course depending on the season), that's a safe way of ensuring we are selecting all the observations in a given night."
+    "As you noticed, we used times from noon to noon. That's just because, as most of the observations happen over night (typically between 20:00 and 06:00, of course depending on the season), that's a safe way of ensuring we are selecting all the observations in a given night."
    ]
   },
   {
@@ -175,10 +174,10 @@
    "id": "c2745d60-befe-4d60-84d2-4a8c43b50d18",
    "metadata": {},
    "source": [
-    "## 3.2. Light curve: integral flux vs time\n",
+    "## 3.3. Light curve: integral flux vs time\n",
     "\n",
-    "We are now concerned with studying the **evolution of the flux in time**: how could we measure it?      \n",
-    "One option would certainly be to perform the spectrum estimation (demostrated in the previous notebook) per each of the observations (or day) separately. In this way we could measure spectral changes run by run (or day by day). Let us actually keep this option in the back of our mind. \n",
+    "We are now concerned with studying the **evolution of the flux in time**: How could we measure it?      \n",
+    "One option would certainly be to perform the spectrum estimation (demostrated in the previous notebook) per each of the observations (or per day) separately. In this way we could measure spectral changes run by run (or day by day). Let us keep this option in the back of our mind. \n",
     "\n",
     "To measure variability in astronomy it is common practice to compile a _light curve_, a graph of the light intensity or brightness as a function of time. To represent the brightness of a source in gamma rays we will consider the **integral flux** above a certain energy, $E_{\\rm thr}$\n",
     "\n",
@@ -189,7 +188,7 @@
     "\n",
     "where $\\hat{\\theta}$ represents the parameters of the differential flux model $\\frac{{\\rm d}\\phi}{{\\rm d}E}$ we adjusted to the data. $E_{\\rm thr}$, the extreme of integration, can depend on the analysis, or on the physics we are interested in. One can in principle perform the likelihood fit of the previous notebook in a given time interval (might be an observation, a day, a week) to determine $\\frac{{\\rm d}\\phi}{{\\rm d}E}(E; \\hat{\\theta})$, and then simply integrate the spectrum obtained.\n",
     "\n",
-    "It is more common practice to fix the parameters of the spectrum adopted $\\hat{\\theta}$, except for the normalisation $\\phi_0$. This is very similar to what we did in the flux point computation. In that case, we readjusted the best-fit value for $\\phi_0$ using _all the events within an estimated energy bin_. We now re-adjust it using _all the events in a single time interval_.\n",
+    "It is more common practice to fix the parameters of the spectrum adopted $\\hat{\\theta}$, except for the normalisation $\\phi_0$. This is very similar to what we did in the flux point computation. In that case, we re-adjusted the best-fit value for $\\phi_0$ using _all the events within an estimated energy bin_. We now re-adjust it using _all the events in a single time interval_.\n",
     "Given the parallel between the processes of flux points and light curve estimation, `Gammapy` provides a `LightCurveEstimator`  that works very simlarly to the `FluxPointsEstimator`.\n",
     "\n",
     "Let us then compute the light curve for Mrk421. Which model should we assume for the likelihood fitting? In the paper presenting this dataset ([MAGIC Collaboration, 2020](https://ui.adsabs.harvard.edu/abs/2020ApJS..248...29A/abstract)) we read:\n",
@@ -254,7 +253,7 @@
    "id": "dff6a784-60c3-4b72-99d8-029b50685569",
    "metadata": {},
    "source": [
-    "We, obtained values quite similar to the average spectrum presented in the paper, let us go ahead and compute the LC with the `LightCurveEstimator`, if no time interval is specified, then a flux point per each observation will be estimated. Let us compute the light curve above 1 TeV, as done in the paper."
+    "We, obtained values quite similar to the average spectrum presented in the paper. Let us go ahead and compute the LC with the `LightCurveEstimator`. If no time interval is specified, then one flux point will be estimated for each observation. Let us compute the light curve above 1 TeV, as done in the paper."
    ]
   },
   {
@@ -337,15 +336,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6a72915-9060-430c-adfa-ed8ca4424544",
+   "id": "5355e935",
    "metadata": {},
    "source": [
     "### Exercise 3.1.\n",
-    "Could you compute the LC assuming a power law spectral model?\n",
+    "Compute the light curve of Mrk 421 assuming a power law spectral model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc82159f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6a72915-9060-430c-adfa-ed8ca4424544",
+   "metadata": {},
+   "source": [
     "\n",
-    "## 3.2. Custom time binning\n",
+    "## 3.4. Custom time binning\n",
     "Without specifying any time intervals for the `LightCurveEstimator`, the duration of each run was used for the bins in energy.   \n",
-    "Let us now adopt a custom time binning: let us compute the daily (or, more properly, nightly) integral fluxes. I'll be using MJD to define time intervals here, again I'll consider the bin centred at midnight."
+    "Let us now adopt a custom time binning: let us compute the daily (or, more properly, nightly) integral fluxes. We will use MJD to define the time intervals and again the center of a bin is considered to be at midnight."
    ]
   },
   {
@@ -414,9 +428,9 @@
    "id": "5177d4e3-af30-4ef1-8dbf-06dca2efe9c4",
    "metadata": {},
    "source": [
-    "## 3.3. Light curve: spectral parameters vs time\n",
+    "## 3.5. Light curve: spectral parameters vs time\n",
     "\n",
-    "For the integral flux estimation we froze all the spectral parameters except for the amplitude. This type of light curve shows us only the overall flux variation, without displaying the change in spectral parameters. It is common practice in high-energy astronomy (whenever we can measure a spectrum) to make a plot of the spectral parameters vs time. Let us use a power law, for simplicty, and let us compute the daily amplitudes and spectral indexes. We will now use the function `select_time` but for the `Datasets`, to select and fit those in a single day."
+    "For the integral flux estimation we froze all the spectral parameters except for the amplitude. This type of light curve shows us only the overall flux variation, without displaying the change in spectral parameters. It is common practice in high-energy astronomy (whenever we can measure a spectrum) to make a plot of the spectral parameters vs time. Let us use a power-law, for simplicty, and let us compute the daily amplitudes and spectral indexes. We will now use the function `select_time` but for the `Datasets`, to select and fit those in a single day."
    ]
   },
   {
@@ -501,9 +515,9 @@
    "id": "8635fb04-be6d-40fa-86aa-59bbd5785aa0",
    "metadata": {},
    "source": [
-    "## 3.3.1 Harder when brighter\n",
+    "## 3.5.1 Harder when brighter\n",
     "\n",
-    "In X- and gamma-ray astronomy, the \"harder when brighter\" behavior refers to the phenomenon where the spectrum becomes harder ($< 2$) as their brightness increases. Observing this type of behaviour gives us relevant info into the acceleration mechanisms of the source. We can check if our source shows this behaviour, by making a plot of the integral flux against the spectral index."
+    "In X-ray as well as gamma-ray astronomy, the \"harder when brighter\" behavior refers to the phenomenon where the spectrum becomes harder ($< 2$) as the source brightness increases. Observing this type of behaviour gives us relevant information about the acceleration mechanisms of the source. We can check if Mrk 421 shows this behaviour, by making a plot of the integral flux against the spectral index."
    ]
   },
   {
@@ -544,8 +558,8 @@
    "source": [
     "We indeed observe this correlation.\n",
     "\n",
-    "## 3.4. Light curve: intra-run variability\n",
-    "Going back to the light curve, we can observe that the flare of 13th of April is the one showing not only the highest flux, but also the highest variability. In such cases (very high flux and variability), one might want to check for variability (and thus check the light curve) on even smaller scales than that of a single observational run (typically 20-30 minutes for MAGIC). Let us focus on the 13th of April and let us compute a LC with 5-minutes binning."
+    "## 3.6. Light curve: intra-run variability\n",
+    "Going back to the light curve, we can observe that the flare on 13th of April is the one showing not only the highest flux, but also the highest variability. In such cases (very high flux and variability), one might want to check for variability (and thus check the light curve) on even smaller scales than that of a single observational run (typically 20-30 minutes for MAGIC). Let us focus on the 13th of April and let us compute a LC with 5-minute binning."
    ]
   },
   {
@@ -573,7 +587,9 @@
    "id": "13bc390e-4479-462d-9c02-bcfd6f76b378",
    "metadata": {},
    "source": [
-    "Now let us make divide the day in 5 minutes intervals. **Warning**: in case the time binning is smaller than the run (and hence `Observation` and `Dataset` duration), one must go back to the observations and cut them into smaller times, before creating new data sets, reducing and fitting them. "
+    "Now let us divide the day in 5 minutes intervals.\n",
+    "\n",
+    "**Warning**: in case the time binning is smaller than the run (and hence `Observation` and `Dataset` duration), one must go back to the observations and cut them into smaller times, before creating new data sets, reducing and fitting them. "
    ]
   },
   {
@@ -583,6 +599,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# running this cell can take a few moments\n",
     "duration = 5 * u.min\n",
     "\n",
     "# let us split the day in 10 minutes interval\n",
@@ -676,9 +693,9 @@
    "source": [
     "**Note**: this is just an illustrative example. Be very careful on how you bin your LC, deciding on the optimal binning is a delicate task. \n",
     "\n",
-    "## 3.4. Light curve: fitting the light curve\n",
+    "## 3.7. Light curve: fitting the light curve\n",
     "\n",
-    "Let us use now `Gammapy`'s temporal models to fit the flux points of the LC. Let us start with a simple linear model."
+    "Let us now use `Gammapy`'s temporal models to fit the flux points of the LC. Let us start with a simple linear model."
    ]
   },
   {
@@ -839,15 +856,23 @@
    "metadata": {},
    "source": [
     "### Exercise 3.2\n",
-    "Could you estimate the goodness of this fit?"
+    "Estimate the goodness of this fit. "
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffbae33c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:gammapy-1.3]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-gammapy-1.3-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -859,7 +884,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.12"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,

--- a/4_multiple_sources_in_fov.ipynb
+++ b/4_multiple_sources_in_fov.ipynb
@@ -8,7 +8,7 @@
     "# 4. Analysis of two sources in the same field of view\n",
     "\n",
     "## 4.1. Context\n",
-    "This notebook displays the most advanced capabilities of the one-dimensional analysis with DL3 data and `Gammapy` and is also a preview of the capability we would like to achieve with the three-dimensional analysis: to analyse several sources in the field of view. We will use observations of 1ES1218+304 gathered in 2018 and 2019 to analyse, using the same dataset, this source and 1ES1215+303. These two blazars are separated by only 0.8 degrees, which is smaller than the MAGIC field of view radius (1.5 degrees)."
+    "This notebook displays the most advanced capabilities of the one-dimensional analysis with DL3 data and `Gammapy` and is also a preview of the capability we would like to achieve with the three-dimensional analysis: to analyse several sources in the field of view. We will use observations of the blazar [1ES1218+304](https://simbad.u-strasbg.fr/simbad/sim-id?Ident=1ES+1218%2B304&utm_source=chatgpt.com) gathered in 2018 and 2019. Using the same dataset, we also analyze the blazar [1ES1215+303](https://simbad.u-strasbg.fr/simbad/sim-id?Ident=1ES+1215%2B303&utm_source=chatgpt.com). These two sources are separated by only 0.8 degrees, which is smaller than the MAGIC field of view radius (1.5 degrees)."
    ]
   },
   {
@@ -18,7 +18,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# - basic imports (numpy, astropy, regions, matplotlib)\n",
+    "# - basic imports (numpy, astropy, regions, matplotlib) \n",
     "import astropy.units as u\n",
     "from astropy.coordinates import SkyCoord\n",
     "from astropy.io.fits.verify import VerifyWarning\n",
@@ -81,7 +81,7 @@
    "source": [
     "## 4.2. 1ES1218+304 analysis\n",
     "\n",
-    "The observations in this data set were performed wobbling around the coordinates of 1ES1218+304, with the standard offset (for MAGIC observations) of $0.4^{\\circ}$. Let us compute spectrum and light curve for this source first. As we explained in the previous notebooks, being the _off_ regions symmetrical to the _on_ w.r.t. the camera center, they will sit on a circle of radius $0.4^{\\circ}$ around the camera center. There is something to be taken into account in this particular case, though. 1ES1215+303 that is an active gamma-ray emitter, sits in this very same field of view, and we want to be sure that none of this _off_ regions sits on top of 1ES1215+303, otherwise our background estimation will be contaminated by gamma rays. All these processes are automatically accounted for by `Gammapy` in the data reduction.\n",
+    "The observations in this data set were performed wobbling around the coordinates of 1ES1218+304, with the standard offset (for MAGIC observations) of $0.4^{\\circ}$. Let us first compute the spectrum and the light curve for this source. As we saw in the previous notebooks, the _off_ regions are placed symmetrically to the _on_ region with respect to the camera center, so they will sit on a circle of radius $0.4^{\\circ}$ around it. There is something to be taken into account in this particular case, though. The source 1ES1215+303, an active gamma-ray emitter, sits in this very same field of view. We want to be sure that none of the _off_ regions coincides with 1ES1215+303, otherwise our background estimation would be contaminated by its gamma rays. All these processes are automatically accounted for by `Gammapy` in the data reduction.\n",
     "\n",
     "### 4.2.1. Sources, signal, background, and exclusion regions visualization\n",
     "\n",
@@ -150,7 +150,7 @@
    "id": "1cdee9ee-1148-4a6b-86a2-25d34a399ae2",
    "metadata": {},
    "source": [
-    "All the maps are centered on 1ES1218+304, by looking at these four observations, we can cleary see how the telescope is \"wobbling\" around the source of interest. In the penultimate observation plotted, we can clearly see the problem we were describing: one of the _off_ regions overalps with the secound source. This will be accounted for in the data reduction, by creating an _exclusion mask_, let us do it.\n",
+    "All the maps are centered on the source of interest (1ES1218+304). By looking at these four observations, we can cleary see how the telescope is \"wobbling\" around it. In the second-to-last observation plotted, we can clearly see the problem we were describing: one of the _off_ regions overalps with the second source (1ES1215+303). This will be accounted for in the data reduction, by creating an _exclusion mask_, let us do it.\n",
     "\n",
     "### 4.2.2. Spectrum extraction and fit\n",
     "\n",
@@ -195,7 +195,7 @@
    "id": "f36a0fa1",
    "metadata": {},
    "source": [
-    "Compared to the previous data reduction, we have to specify an additional parameter when we compute the background: an **exclusion region** corresponding to the source that is not of our interest, 1ES1215+303. We can create it as a circular region of radius 0.2 deg around the coordinates of 1ES1215+303 (which we already defined to plot the sky maps). We have to convert it to a pixel mask, we do so by _blacking out_ the pixels of the skymap geometry that fall within the exclusion region."
+    "Compared to the previous data reduction, we have to specify an additional parameter when we compute the background: an **exclusion region** corresponding to the source that is not of our interest (1ES1215+303). We can create it as a circular region of radius 0.2 deg around its coordinates (which we already defined to plot the black star in the sky maps). We have to convert it to a pixel mask. We do so by _blacking out_ the pixels of the skymap geometry that fall within the exclusion region."
    ]
   },
   {
@@ -340,7 +340,7 @@
    "id": "46a55366-6b01-4499-bef6-d76a87c72355",
    "metadata": {},
    "source": [
-    "Quite a steep spectrum (we have obtained an index of 3). We also observe that the flux points don't fall exactly on top of the broad band model, as if there was more curvature to them.   \n",
+    "Quite a steep spectrum: we have obtained an index of 3 (see `PowerLawSpectralModel` above). We also observe that the flux points don't fall exactly on top of the broad band model, as if there was more curvature to them.   \n",
     "We remember that on their way to Earth, gamma rays are absorbed by the Extragalactic Background Light (EBL), and this effect is more pronounced at higher energies. We can try to fit the spectrum with a power law model absorbed by the EBL, using one of the models implemented in `Gammapy`. Let us do it."
    ]
   },
@@ -442,7 +442,7 @@
    "source": [
     "## 4.3. 1ES1215+303 analysis\n",
     "\n",
-    "Would it be possible now to analyse 1ES1215+303 with the same dataset?   \n",
+    "Would it be possible now to analyse the other blazar in the field (1ES1215+303) with the same dataset?   \n",
     "As we said before, the observations in this data set were conducted wobbling around the coordinates of 1ES1218+304,   \n",
     "This will imply that 1ES1215+303 will be observed at different offsets in the camera, depending on the wobble position.\n",
     "\n",
@@ -531,9 +531,9 @@
    "id": "4035fe74-a4d2-49c5-9081-50f372071555",
    "metadata": {},
    "source": [
-    "If you remember from the first notebook, the IRFs that we have been using up to now are computed for a single offset, that of the source from the camera center (0.4 deg, as that is the standard offset of most MAGIC observations). \n",
+    "As in the first notebook, the IRFs that we have been using up to now are computed for a single offset: the source's separation from the camera center (0.4 deg, as that is the standard offset of most MAGIC observations). \n",
     "\n",
-    "These _single-offset_ IRF would not be useful for this case, as we need to know the response of our system at different offsets. For such cases, MAGIC produces _multi-offset_ IRFs, that is IRFs computed at several offsets from the camera center. `Gammapy` is able to handle these multi-offset IRFs and to interpolate them at the required offset. Let us check, using the effective area, that the offsets we computed for 1ES1215+303 are indeed included in the multi-offset IRFs that we have in our DL3 data."
+    "These _single-offset_ IRF is no longer useful for this new case, as we need to know the response of our system at different offsets. For such cases, MAGIC produces _multi-offset_ IRFs, that is IRFs computed at several offsets from the camera center. `Gammapy` is able to handle these multi-offset IRFs and to interpolate them at the required offset. Let us check, using the effective area, that the offsets we computed for 1ES1215+303 are indeed included in the multi-offset IRFs that we have in our DL3 data."
    ]
   },
   {
@@ -543,7 +543,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "observations[0].aeff.plot()"
+    "observations[0].aeff.plot();"
    ]
   },
   {
@@ -563,7 +563,7 @@
    "metadata": {},
    "source": [
     "### 4.3.2. 1ES1215+303 Spectrum extraction and fit\n",
-    "At the data reduction level, the only difference w.r.t. the previous analysis is the definition of the exclusion mask, that now has to be centered on 1ES1218+304. The rest of the analysis is exactly the same as before. `Gammapy` will take care of interpolating the IRFs at the required offsets for each of the runs."
+    "At the data reduction level, the only difference w.r.t. the previous analysis is that the definition of the exclusion mask now has to be centered on 1ES1218+304. The rest of the analysis is exactly the same as before. `Gammapy` will take care of interpolating the IRFs at the required offsets for each of the runs."
    ]
   },
   {
@@ -732,22 +732,44 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe7dc096",
+   "id": "578b5436",
    "metadata": {},
    "source": [
     "### Exercise 4.1.\n",
-    "Try to fit the spectrum of 1ES1218+303 with a log parabola model absorbed by the EBL. Is the fit better than with a simple power law?\n",
-    "\n",
-    "### Exercise 4.2. (homework)\n",
-    "Could you compute the light curve of both sources, could you say which one is more variable?"
+    "Fit the spectrum of 1ES1218+303 with a log parabola model absorbed by the EBL. Is the fit better than with a simple power law?"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b29e11f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe7dc096",
+   "metadata": {},
+   "source": [
+    "### Exercise 4.2. (homework)\n",
+    "Compute the light curve of both sources. Which one is more variable?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf3422c1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "gammapy-1.3",
+   "display_name": "Python [conda env:gammapy-1.3]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-gammapy-1.3-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -759,7 +781,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.12"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,

--- a/5_pulsar_analysis.ipynb
+++ b/5_pulsar_analysis.ipynb
@@ -23,9 +23,9 @@
     "\n",
     "Phase at an instant $t$ can be broken up into an integer part $\\lfloor\\Phi(t)\\rfloor$ and a fractional part $\\varphi=\\{\\Phi\\}=(\\Phi\\mod1)$. The integer part is just counting how many full turns the pulsar has done until that moment. The fractional part $\\varphi$, which is often called simply \"phase\", relates instead to the angle the pulsar is presenting to the observer at that very moment $t$. Given the periodic nature of pulsar signals, the emission as a function of $\\{\\varphi\\}$ is of great physical importance, because it conveys information on what part of the pulsar magnetosphere is responsible for what emission. Studying the instantaneous emission of a pulsar as a function of $\\varphi$ is impossible, as very few $\\gamma$-rays can be measured in the short time span of a single pulsar rotation (typically less than a second). Instead, data is collected for a much longer time interval, and a value $\\varphi_i$ is then attributed to each event, based on a model of the pulsar rotation that is commonly called a *pulsar ephemeris*. The data can later be grouped using the values of $\\varphi_i$ to get a measurement of the emission from different *phase regions* defined by sub-intervals $(\\varphi_i,\\varphi_f) \\subseteq (0,1)$ corresponding to different parts of the magnetosphere. Generating and applying *ephemerides* for pulsars is beyond the scope of this notebook.\n",
     "\n",
-    "All the $\\gamma$-ray pulsars detected by IACTs so far present a quiescent state during a phase interval $(\\varphi_{i}^0, \\varphi_{f}^0)$ that we call the \"off region\". That is to say, at every cycle of the pulsar, for a certain time the $\\gamma$-ray source effectively turns off. This fact can be exploited to define the background estimator for the computation of spectra *as a region of phase*, rather than a function of space as in the various ways employed for the construction of background maps. This procedure has the advantage to guarantee an estimate from a background that is both quasi-simultaneous (down to the sub-second time span of a pulsar period) and from the very same region of the sky the source we want to measure is at. As a result, the background estimate uncertainty, among the largest contributors to the systematic uncertainties for regular IACTs analyses, is effectively removed. Thanks to this strategy the dim, low-energy pulsar emission can be soundly detected even in the presence of a background that is much larger than the signal itself ($SNR\\sim1\\%$), which would otherwise \"drown\" the signal.\n",
+    "All the $\\gamma$-ray pulsars detected by IACTs so far present a quiescent state during a phase interval $(\\varphi_{i}^0, \\varphi_{f}^0)$ that we call the \"off region\". That is to say, at every cycle of the pulsar, for a certain time the $\\gamma$-ray source effectively turns off. This fact can be exploited to define the background estimator for the computation of spectra *as a region of phase*, rather than a function of space as presented in the previous notebooks. This procedure has the advantage to guarantee an estimate from a background that is both quasi-simultaneous (down to the sub-second time span of a pulsar period) and from the very same region of the sky the source we want to measure is at. As a result, the background estimate uncertainty, among the largest contributors to the systematic uncertainties for regular IACTs analyses, is effectively removed. Thanks to this strategy the dim, low-energy pulsar emission can be soundly detected even in the presence of a background that is much larger than the signal itself ($SNR\\sim1\\%$), which would otherwise \"drown\" the signal.\n",
     "\n",
-    "In the following, we will see how to do a simple pulsed analysis using MAGIC DL3 files of the Geminga pulsar and gammapy. These DL3 files were further processed with a simple script to add an extra column to their FITS event table \"PULSE_PHASE\", which contains the value of $\\varphi$ for every event. Much of this notebook is based upon the master thesis work of Yunhe Wang, which I refer to for further details."
+    "In the following, we will see how to do a simple pulsed analysis using MAGIC DL3 files of the Geminga pulsar in `Gammapy`. These DL3 files were further processed with a simple script to add an extra column to their FITS event table \"PULSE_PHASE\", which contains the value of $\\varphi$ for every event. Much of this notebook is based upon the master thesis work of Yunhe Wang, which provides further details."
    ]
   },
   {
@@ -41,7 +41,7 @@
    "id": "07f21120-517e-41ed-a5d7-77903db60a14",
    "metadata": {},
    "source": [
-    "A diagram of the number of recorded excess events versus the rotational phase $\\varphi$ (variously called \"lightcurve\", \"phasogram\", \"phaseogram\", etc. by different people) bears information on the relative intensities of the emission from different parts of the magnetosphere even when not fully accounting for the instrument exposure. This is because the IRFs are independent on phase, which is the same as says that they don't vary on the sub-second scale of a single pulsar rotation. Unfortunately, `gammapy` does not have a method to build phaseograms, so we use astropy's fits module to read the fits files directly.\n",
+    "A diagram of the number of recorded excess events versus the rotational phase $\\varphi$ (variously called \"lightcurve\", \"phasogram\", \"phaseogram\", etc. by different people) bears information on the relative intensities of the emission from different parts of the magnetosphere even when not fully accounting for the instrument exposure. This is because the IRFs are independent on phase, which is the same as says that they don't vary on the sub-second scale of a single pulsar rotation. Unfortunately, `Gammapy` does not have a method to build phaseograms, so we use [astropy's fits module](https://docs.astropy.org/en/stable/io/fits/index.html) to read the fits files directly.\n",
     "\n",
     "To produce a meaningful phaseogram, energy-dependent $\\theta^2$ cuts should be applied to reduce the effect of the large cosmic ray background. Gammaness/Hadronness cuts are already applied when creating pointlike DL3 files, whereas the $\\theta^2$ ones are incorporated into the definition of the IRFs. In order to plot a phaseogram and calculate the significance of the emission from a certain phase region, we have to collect events that satisfy both the gammaness and $\\theta^2$ cut."
    ]
@@ -54,11 +54,12 @@
    "outputs": [],
    "source": [
     "import glob\n",
-    "\n",
     "from   astropy.io    import fits\n",
     "from   astropy.table import Table\n",
     "from   astropy.coordinates import angular_separation\n",
-    "import astropy.units as u"
+    "import astropy.units as u\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
    ]
   },
   {
@@ -95,7 +96,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ifiles = glob.glob(\"data/Geminga/20*Geminga*.fits\")\n",
+    "ifiles = glob.glob(\"../acme_magic_odas_data/data/Geminga/20*Geminga*.fits\")\n",
     "phases = []\n",
     "\n",
     "for ifile in ifiles:\n",
@@ -226,7 +227,7 @@
    "id": "c7198227-46ea-416f-b4d0-9cdc38bf9594",
    "metadata": {},
    "source": [
-    "So we have found a $6.4\\,\\sigma$ significant signal from Geminga's P2 pulse. We proceed to make its spectrum using gammapy."
+    "So we have found a $6.4\\,\\sigma$ significant signal from Geminga's P2 pulse. We proceed to make its spectrum using `Gammapy`."
    ]
   },
   {
@@ -235,7 +236,7 @@
    "metadata": {},
    "source": [
     "# Spectra\n",
-    "As you will see, this is all very standard, and minimally different from any other point-like analysis, for instance that of an AGN. The main difference is importing and using gammapy's class `PhaseBackgroundMaker` to specify the signal and background regions in phase."
+    "As you will see, this is all very standard, and minimally different from any other point-like analysis, for instance that of an AGN. The main difference is importing and using `Gammapy`'s class `PhaseBackgroundMaker` to specify the signal and background regions in phase."
    ]
   },
   {
@@ -245,16 +246,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "from astropy             import units as u\n",
     "from astropy.coordinates import SkyCoord\n",
     "\n",
     "from IPython.display import display\n",
     "\n",
     "from regions import PointSkyRegion\n",
     "\n",
+    "# - Gammapy's imports\n",
     "from gammapy.data            import DataStore\n",
     "from gammapy.maps            import MapAxis, RegionGeom\n",
     "from gammapy.datasets        import Datasets, SpectrumDataset\n",
@@ -280,9 +278,9 @@
    "id": "4b8b8543-6a40-4430-a781-096d489eada4",
    "metadata": {},
    "source": [
-    "Here we specify the position of the source and the sizes and binning of the energy axes. This binning is a slight variation of the standard MARS one, with the extremes shifted so that it has a bin beginning at the reconstructed energy of $25\\,\\text{GeV}$, the minimum meaningful one that was found by folding a spectrum similar to the one of Geminga with the IRFs.\n",
+    "Here we specify the position of the source and the sizes and binning of the energy axes. This binning is a slight variation of the standard MAGIC Analysis and Reconstruction Software (MARS), with the extremes shifted so that it has a bin beginning at the reconstructed energy of $25\\,\\text{GeV}$, the minimum meaningful one that was found by folding a spectrum similar to the one of Geminga with the IRFs.\n",
     "\n",
-    "These data also employed Geminga-tailored Monte-Carlo simulations to determine the IRFs and train the RF for the gamma-hadron separation, direction and energy classification. These are MCs with a larger statistics at the lowest energies, that track the path of Geminga in the sky as seen from La Palma. This is similar to the declination bands of LST-1 MCs. Since the target of these observations was the pulsar, the maximum simulated energy of these MCs is $5\\,\\text{TeV}$. As a result, nothing with an energy greater than few $\\text{TeV}$ can be reconstructed meaningfully from this data."
+    "These data also employed Geminga-tailored Monte-Carlo simulations to determine the IRFs and train the RF for the gamma-hadron separation, direction and energy classification. These are MCs with a larger statistics at the lowest energies, that track the path of Geminga in the sky as seen from La Palma. This is similar to the declination bands of [LST-1](https://www.ctao.org/emission-to-discovery/telescopes/) MCs. Since the target of these observations was the pulsar, the maximum simulated energy of these MCs is $5\\,\\text{TeV}$. As a result, nothing with an energy greater than few $\\text{TeV}$ can be reconstructed meaningfully from this data."
    ]
   },
   {
@@ -326,7 +324,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_store   = DataStore.from_dir(\"data/Geminga\")\n",
+    "data_store   = DataStore.from_dir(\"../acme_magic_odas_data/data/Geminga\")\n",
     "observations = data_store.get_observations(required_irf=\"point-like\")\n",
     "print(data_store)"
    ]
@@ -386,7 +384,7 @@
    "metadata": {},
    "source": [
     "### Phased data\n",
-    "Here we create the phase intervals corresponding to the signal and the background, use the `PhaseBackgroundMaker` class to generate the background model, and load the actual observations. From here on everything that follows is a normal, point-like gammapy analysis."
+    "Here we create the phase intervals corresponding to the signal and the background, use the `PhaseBackgroundMaker` class to generate the background model, and load the actual observations. From here on everything that follows is a normal, point-like `Gammapy` analysis."
    ]
   },
   {
@@ -1064,21 +1062,29 @@
     "## Spectral points\n",
     "Unfortunately, the gammapy spectral points algorithm is unsuitable for very steep spectra with large energy resolution and bias, which is precisely the case for pulsars. This does not stem from a technical limitation (that means: you can run the flux point maker on these data, and you will obtain results), but from an intrinsic inadeguacy of the rationale the procedure is based on.\n",
     "\n",
-    "In gammapy, spectral points are determied by fitting a power-law locally tangent to the global fitted model (optionally the index can be fixed to 2 instead, i.e. a flat constant in SED) on each single bin of the counts vs. **reconstructed** energy histogram. The normalization factor of each of those power-laws is then used to make spectral points, that are attributed a range equal to the estimated energy bin they were created from. These points will be aligned to the reconstructed energy edges.\n",
+    "In `Gammapy`, spectral points are determied by fitting a power-law locally tangent to the global fitted model (optionally the index can be fixed to 2 instead, i.e. a flat constant in SED) on each single bin of the counts vs. **reconstructed** energy histogram. The normalization factor of each of those power-laws is then used to make spectral points, that are attributed a range equal to the estimated energy bin they were created from. These points will be aligned to the reconstructed energy edges.\n",
     "\n",
-    "When the energy bias is very large events in the reconstructed energy bin $20\\,\\text{GeV}$ to $40\\,\\text{GeV}$ in reality map to events between $10\\,\\text{GeV}$ and $30\\,\\text{GeV}$. The spectral fitting procedure of gammapy obviously accounts for this migration in the IRF, but the spectral point calculator will assign the flux computed from those events to a point (roughly) between $20\\,\\text{GeV}$ and $40\\,\\text{GeV}$. This means that altough the data effectively contains events down to $10\\,\\text{GeV}$, as can be seen by plotting the energy threshold, no spectral point can be produced down there. See for instance the LST-1 Geminga paper here: https://www.aanda.org/articles/aa/full_html/2025/06/aa54350-25/aa54350-25.html .\n",
+    "When the energy bias is very large events in the reconstructed energy bin $20\\,\\text{GeV}$ to $40\\,\\text{GeV}$ in reality map to events between $10\\,\\text{GeV}$ and $30\\,\\text{GeV}$. The spectral fitting procedure of `Gammapy` obviously accounts for this migration in the IRF, but the spectral point calculator will assign the flux computed from those events to a point (roughly) between $20\\,\\text{GeV}$ and $40\\,\\text{GeV}$. This means that altough the data effectively contains events down to $10\\,\\text{GeV}$, as can be seen by plotting the energy threshold, no spectral point can be produced down there. See for instance the [LST-1 Geminga paper](https://www.aanda.org/articles/aa/full_html/2025/06/aa54350-25/aa54350-25.html).\n",
     "\n",
     "Different groups have come up with different approaches to this issue. H.E.S.S., for instance, does not publish data-points for its pulsars, but only the spectral fits with the associated uncertainty butterflies.\n",
     "\n",
-    "An alternative approach to produce spectral points within a Bayesian framework and using Markov-chain monte-carlo sampling has been put forward in the master thesis of Yunhe Wang, under my supervision. In such a Bayesian approach, setting a prior on the model \"parameters\" (the flux of each spectral point is a parameter) is mathematically equivalent to imposing a regularization procedure, as is done in MARS by the infamous CombUnfold program. The interested reader might find information in the thesis of Yunhe Wang: https://www.mpp.mpg.de/~ceribell/YunheWang_thesis_20250214.pdf"
+    "An alternative approach to produce spectral points within a Bayesian framework and using Markov-chain monte-carlo sampling has been put forward in the master thesis of Yunhe Wang, under my supervision. In such a Bayesian approach, setting a prior on the model \"parameters\" (the flux of each spectral point is a parameter) is mathematically equivalent to imposing a regularization procedure, as is done in MARS by the infamous CombUnfold program. The interested reader might find information in the [thesis of Yunhe Wang](https://www.mpp.mpg.de/~ceribell/YunheWang_thesis_20250214.pdf)."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad41074d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:gammapy-1.3]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-gammapy-1.3-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1090,7 +1096,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.12"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ACME-sponsored 1st MAGIC Open Data-Analysis School
 
-This repository contains the material and the data for the [1st open MAGIC data-analysis school](https://acme-magic-odas.sciencesconf.org/).
+This repository contains the material for the [1st open MAGIC data-analysis school](https://acme-magic-odas.sciencesconf.org/).
+The corresponding data will soon be provided as well. 
 
 ## Context
 Gamma-ray astronomy at the highest energy has been traditionally conducted with proprietary data and software.
@@ -17,11 +18,18 @@ the experience acquired in the school will be directly transferable to the analy
 All the material (lessons and hands-on recording, data, and software) will remain openly available in this repository after the school.
 
 ## Introductory material
-If you are not familiar with Gamma-ray astronomy, you can find an [introductory lecture on this field](https://www.youtube.com/@magictelescopes8632/) 
-and on [the analysis of its data](https://www.youtube.com/@magictelescopes8632/)
-in the [MAGIC Collaboration's YouTube Channel](https://www.youtube.com/@magictelescopes8632/).
+If you are not familiar with Gamma-ray astronomy, you can find an [introductory lecture](https://youtu.be/xvbSOgyHxrQ) on this field and another on the [analysis of its data](https://youtu.be/HqxcLnD2uMs) in the [MAGIC Collaboration's YouTube Channel](https://www.youtube.com/@magictelescopes8632/).
 
 ## Software Requirements
-The only software required to succesfully participate in the school is [Gammapy](https://gammapy.org/).   
+The only software required to successfully participate in the school is [Gammapy](https://gammapy.org/).   
 Check the installation instructions [here](https://docs.gammapy.org/1.3/getting-started/index.html#installation).   
 We recommend creating a virtual environment, as shown [here](https://docs.gammapy.org/1.3/getting-started/index.html#recommended-setup).
+
+## Get started
+Clone this git repository to your own machine (inside your dedicated conda environment), e.g.:
+```bash
+git clone https://github.com/magic-telescopes/acme_magic_odas.git
+
+
+
+We hope you enjoy the school! Please don't hesitate to reach out if you have any questions.


### PR DESCRIPTION
Some more minor things I didn't implement:

- general: could suppress the Warning: 'THETA' axis is stored as a scalar -- converting to 1D array.

- general: in the first nb you work with **_Question 1.1_** which is nice and could be used in the later ones as well. 

- nb1: plot of energy dispersion (true x, estimated energy) could have a color bar legend

- nb2: heading # 2.3. is missing 

- nb2: "We can see the parameters, and now that we have assigned the model, we can see something else." --> this ends up a little bit los, maybe clarify what we can see or explicitly make it a Question? Or maybe "We can also check the contribution of this data set to the total likelihood." is just in the wrong spot? Because "As we can see,.." seems to fit the above. "What happens to the predicted counts? And what happens to the likelihood statistics?" --> could nicely be turned into a formatted Question, too.

- nb2: "We compare the results we have obtained with a theoretical model of the SED and with another measurement performed by MAGIC." 
--> should spectral_model.plot(label="LST") be "MAGIC"?
--> would be nice to add the references, maybe:
    * Reference: [MAGIC Collaboration (2015), JHEAP, 5, p. 30-38.](https://ui.adsabs.harvard.edu/abs/2015JHEAp...5...30A/abstract)
    * Reference: [Meyer et al. (2010), A&A, 523, A2](https://ui.adsabs.harvard.edu/abs/2010A%26A...523A...2M/abstract)

- nb3: just as a note: heading # 2.3 was used several times. I adjusted such that all following ones increased the count but maybe it was intended to go as 2.3.1. and so on? please double check, especially with the latter following ones. Currently 3.5.1. is a standalone subheading
